### PR TITLE
password button onclick show password

### DIFF
--- a/app/account/signup/signup.component.html
+++ b/app/account/signup/signup.component.html
@@ -16,8 +16,14 @@
                     <control-message control="email"></control-message>
                 </div>
                 <div class="form-group">
-                    <label for="password">Password</label>
-                    <input ngControl="password" type="password" class="form-control" [(ngModel)]="registrationModel.Password" [ngFormControl]="signupForm.controls['password']">
+                    <label for="password" >Password</label>
+                    <div class="input-group">
+                        <input ngControl="password" type="password" id="sign-up-password" class="form-control" placeholder="Enter your password" [(ngModel)]="registrationModel.Password" [ngFormControl]="signupForm.controls['password']">
+                        <span class="input-group-btn">
+                            <button catShowPassword type="button" id="btnpassword" class="btn btn-default" type="button">
+                            <span class="glyphicon glyphicon-eye-open" style="height:20px"></span></button>
+                        </span>
+                    </div>
                     <control-message control="password"></control-message>
                 </div>
                 <div class="form-group">

--- a/app/account/signup/signup.component.ts
+++ b/app/account/signup/signup.component.ts
@@ -13,10 +13,11 @@ import { User } from '../shared/user';
 import { AvailibilityResponse } from '../shared/availibility-response';
 import { AppSettings } from  '../../shared/app.settings';
 
+import { CatShowPassword } from '../../directives/cat-show-password';
 @Component({
     selector: 'signup',
     templateUrl: 'app/account/signup/signup.component.html',
-    directives: [MODAL_DIRECTIVES, ModalComponent, TYPEAHEAD_DIRECTIVES, CORE_DIRECTIVES, FORM_DIRECTIVES, ControlMessage],
+    directives: [MODAL_DIRECTIVES, ModalComponent, TYPEAHEAD_DIRECTIVES, CORE_DIRECTIVES, FORM_DIRECTIVES, ControlMessage, CatShowPassword],
     providers: [HTTP_PROVIDERS, AccountService, ValidationService, LocalityService]
 })
 export class SignupComponent implements OnInit {

--- a/app/directives/cat-show-password.ts
+++ b/app/directives/cat-show-password.ts
@@ -1,0 +1,25 @@
+import { Directive, ElementRef, Input } from '@angular/core';
+
+@Directive({
+    selector: '[catShowPassword]',
+    host: {
+        '(mousedown)' : 'mouseDown()',
+        '(mouseup)' : 'mouseUp()',
+    }
+})
+export class CatShowPassword{
+
+    private el: HTMLElement;
+    constructor(el: ElementRef){
+        this.el = el.nativeElement;
+    }
+
+    mouseDown() {
+        document.getElementById('sign-up-password').setAttribute('type', 'text');
+        console.log(document.getElementById('sign-up-password'));
+    }
+
+    mouseUp() {
+        document.getElementById('sign-up-password').setAttribute('type', 'password');
+    }
+}


### PR DESCRIPTION
created a directive named cat-show-password.ts
created a new directory named directives in the app folder

added the button and the icon after the password field in signup.component.html
the catShowPassword directive is added on the button. it contains the js code, which onmousedown event shows the password and vice versa on onmouseup event of the button.

the prefix i used cat-*** for directive name convention.
`document.getElementById('sign-up-password').setAttribute('type', 'text');`

Maybe instead of a CSS Id, we should give all the password field in the app a CSS class, then the directive will be universal. looking for thoughts on this.
