### PR TITLE
Track Order navbar menu tweaks

### DIFF
--- a/app/account/signup/signup.component.html
+++ b/app/account/signup/signup.component.html
@@ -11,7 +11,7 @@
             <div *ngIf="!submitted && selectedUserType">
                 <div class="form-group">
                     <label for="username">Username</label>
-                    <input ngControl="username" type="text" class="form-control" placeholder="Enter your desried username here" [(ngModel)]="registrationModel.UserName" [ngFormControl]="signupForm.controls['username']">
+                    <input ngControl="username" type="text" class="form-control" placeholder="Enter your desired username here" [(ngModel)]="registrationModel.UserName" [ngFormControl]="signupForm.controls['username']">
                     <control-message control="username"></control-message>
                 </div>
                 <div class="form-group">

--- a/app/navbar/navbar.component.css
+++ b/app/navbar/navbar.component.css
@@ -38,3 +38,7 @@ i {
 #job-search-form {
     min-width: 270px !important;
 }
+
+.tracking-modal {
+    margin: 0px 15px 0px 15px;
+}

--- a/app/navbar/navbar.component.html
+++ b/app/navbar/navbar.component.html
@@ -39,13 +39,11 @@
     </modal-header>
     <modal-body class="modal-body">
         <div class="alert alert-info" role="info">
-            Enter your Order Id to know the current status of your order.
-            You will receive an Order Id once you place an order.
-            Your Order Id looks like this: <i>Job-VV1XDFOW</i>
+            Enter your Tracking Id to know the current status of your order.
         </div>
         <form [ngFormModel]="trackJobForm" (submit)="searchJob($event)" role="form" id="job-search-form">
             <div class="input-group">
-                <input type="text" ngControl="jobid" class="form-control" pattern="Job-[A-Z|0-9]{8}" title="ex: Job-VV1XDFOW" placeholder="Track Order">
+                <input type="text" ngControl="jobid" class="form-control" pattern="Job-[A-Z|0-9]{8}" placeholder="ex: Job-VV1XDFOW">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="submit">
                         <i class="fa fa-search" aria-hidden="true"></i>

--- a/app/navbar/navbar.component.html
+++ b/app/navbar/navbar.component.html
@@ -12,16 +12,7 @@
 
         <div class="navbar-collapse collapse" [collapse]="isCollapsed">
 
-            <form [ngFormModel]="trackJobForm" (submit)="searchJob($event)" role="form" class="nav navbar-nav navbar-form" id="job-search-form">
-                <div class="input-group">
-                    <input type="text" ngControl="jobid" class="form-control" pattern="Job-[A-Z|0-9]{8}" title="ex: Job-VV1XDFOW" placeholder="Track Order">
-                    <span class="input-group-btn">
-                        <button class="btn btn-default" type="submit">
-                            <i class="fa fa-search" aria-hidden="true"></i>
-                        </button>
-                    </span>
-                </div>
-            </form>
+
             <ul class="nav navbar-nav navbar-right">
                 <!--<li>
                     <a class="pointer">
@@ -38,3 +29,32 @@
 </div>
 <signup #signup></signup>
 <login #login (onLoginCompleted)="onLoginCompleted($event)"></login>
+
+<modal #trackingModal class="modal_vcenter">
+    <div class="tracking-modal">
+    <modal-header class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h1>Track your Orders</h1>
+        <hr />
+    </modal-header>
+    <modal-body class="modal-body">
+        <div class="alert alert-info" role="info">
+            Enter your Order Id to know the current status of your order.
+            You will receive an Order Id once you place an order.
+            Your Order Id looks like this: <i>Job-VV1XDFOW</i>
+        </div>
+        <form [ngFormModel]="trackJobForm" (submit)="searchJob($event)" role="form" id="job-search-form">
+            <div class="input-group">
+                <input type="text" ngControl="jobid" class="form-control" pattern="Job-[A-Z|0-9]{8}" title="ex: Job-VV1XDFOW" placeholder="Track Order">
+                <span class="input-group-btn">
+                    <button class="btn btn-default" type="submit">
+                        <i class="fa fa-search" aria-hidden="true"></i>
+                    </button>
+                </span>
+            </div>
+        </form>
+    </modal-body>
+    <modal-footer class="modal-footer">
+    </modal-footer>
+    </div>
+</modal>

--- a/app/navbar/navbar.component.ts
+++ b/app/navbar/navbar.component.ts
@@ -11,6 +11,8 @@ import { CartBusService } from '../cart/cart-bus.service';
 import { LocalStorage } from '../shared/local-storage';
 import { Router, ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
+import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
+
 type NavbarState = "PUBLIC" | "SECURED";
 
 interface NavbarElement {
@@ -21,16 +23,27 @@ interface NavbarElement {
 @Component({
     selector: 'navbar',
     templateUrl: 'app/navbar/navbar.component.html',
-    directives: [ROUTER_DIRECTIVES, CollapseDirective, SignupComponent, LoginComponent, CartIconComponent],
+    directives: [
+        ROUTER_DIRECTIVES,
+        CollapseDirective,
+        SignupComponent,
+        LoginComponent,
+        CartIconComponent,
+        ModalComponent
+    ],
     providers: [LocalStorage, CartBusService],
     styleUrls: ['app/navbar/navbar.component.css']
 })
+
 export class NavbarComponent {
     @ViewChild('signup')
     public signUpComponent: SignupComponent;
 
     @ViewChild('login')
     public loginComponent: LoginComponent;
+
+    @ViewChild('trackingModal')
+    public trackingModal : ModalComponent;
 
     AppTitle: string;
     State: NavbarState = "PUBLIC";
@@ -93,10 +106,26 @@ export class NavbarComponent {
 
     searchJob(event){
         this.router.navigateByUrl("/track/" + this.trackJobForm.value.jobid);
+        this.trackingModal.close();
     }
+
+    // Tracking
+
+    trackingProperty = {
+        Title: "Tracking",
+        Event: () => { this.showTrackingModal(); }
+    }
+
+    private showTrackingModal() {
+        this.trackingModal.open();
+    }
+    // End --- Tracking
 
     private _initiatePublicNavElements() {
         this._publicNavElements = new Array<NavbarElement>();
+
+        this._publicNavElements.push(this.trackingProperty);
+
         this._publicNavElements.push({
             Title: "Sign Up",
             Event: () => { this.showSignUpComponent(); }
@@ -115,6 +144,8 @@ export class NavbarComponent {
             Title: "Dashboard",
             Event: () => { this.navigateToDashboard(); }
         });
+
+        this._secureNavElements.push(this.trackingProperty);
 
         // this._secureNavElements.push({
         //     Title: this.userNameString,


### PR DESCRIPTION
Remove Track Order search bar from navbar.

Add Tracking as a menu item in the navbar. Opens up a modal when
'Tracking' is clicked. The 'Track Order' search bar is available inside
the modal.